### PR TITLE
Handle sync-ish Suspense

### DIFF
--- a/src/components/AlbumsSync.astro
+++ b/src/components/AlbumsSync.astro
@@ -1,0 +1,5 @@
+---
+type Props = {};
+---
+
+<p>Albums (synchronous)!</p>

--- a/src/components/Suspense.astro
+++ b/src/components/Suspense.astro
@@ -1,7 +1,72 @@
 ---
-const idx = Astro.locals.suspend(Astro.slots.render("default"));
+type PendingThenable<T> = { status: "pending" };
+type FulfilledThenable<T> = { status: "fulfilled"; value: T };
+type RejectedThenable<T> = { status: "rejected"; reason: unknown };
+
+type Thenable<T> = Promise<T> &
+  (PendingThenable<T> | FulfilledThenable<T> | RejectedThenable<T>);
+
+function instrument<T>(promise: Promise<T>): Thenable<T> {
+  const thenable = promise as Promise<T> & PendingThenable<T>;
+  thenable.status = "pending";
+  thenable.then(
+    (value) => {
+      const fulfilled = promise as Promise<T> & FulfilledThenable<T>;
+      fulfilled.status = "fulfilled";
+      fulfilled.value = value;
+    },
+    (error) => {
+      const rejected = promise as Promise<T> & RejectedThenable<T>;
+      rejected.status = "rejected";
+      rejected.reason = error;
+    }
+  );
+  return thenable;
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+const promise = Astro.slots.render("default");
+const thenable = instrument(promise); // add `.status` and `.value` / `.reason`
+
+const DEADLINE_MS = 5; // arbitrary, might be too high
+await sleep(DEADLINE_MS);
+
+let idx = -1;
+let content = "";
+
+switch (thenable.status) {
+  case "pending": {
+    idx = Astro.locals.suspend(promise);
+    break;
+  }
+  case "rejected": {
+    throw thenable.reason;
+  }
+  case "fulfilled": {
+    if (import.meta.env.DEV) {
+      console.log(
+        `Suspense :: slot resolved within deadline (${DEADLINE_MS}ms), no need to show fallback`
+      );
+    }
+    content = thenable.value;
+    break;
+  }
+}
 ---
 
-<div style="display: contents" data-suspense-fallback={idx}>
-  <slot name="fallback" />
-</div>
+{
+  // rely on `idx/content` instead of `thenable.status` -- that may have changed by the time we get here.
+  // (at least i think it might?)
+  // this way, at least this will be consistent with what we passed to middleware
+  // i.e. if we called suspend(), we'll create a matching fallback here
+  idx !== -1 ? (
+    <div style="display: contents" data-suspense-fallback={idx}>
+      <slot name="fallback" />
+    </div>
+  ) : (
+    <Fragment set:html={content} />
+  )
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import Suspense from "../components/Suspense.astro";
 import Albums from "../components/Albums.astro";
+import AlbumsSync from "../components/AlbumsSync.astro";
 ---
 
 <Layout title="Twitter">
@@ -25,6 +26,10 @@ import Albums from "../components/Albums.astro";
       </a>
     </nav>
     <main>
+      <Suspense>
+        <p slot="fallback">Loading... (shouldn't appear)</p>
+        <AlbumsSync />
+      </Suspense>
       <Suspense>
         <p slot="fallback">Loading...</p>
         <Albums ms={3000} />


### PR DESCRIPTION
If the contents of a Suspense finish within a deadline (arbitrarily picked 5ms), we don't need to send a fallback, and can send it synchronously. This probably needs some tweaking, but seems like a better UX -- we probably don't want to show a fallback if it's going to immediately get replaced by actual content. 

(Similarly, it might be good to have a way to throttle the <script>s that are comming in, so that they don't insert sooner than ~300ms from when the fallback came into view? iirc that's what React's Suspense does to avoid flickering fallbacks)